### PR TITLE
__set_name__ logic error fix

### DIFF
--- a/src/dataclass_rest/method.py
+++ b/src/dataclass_rest/method.py
@@ -18,6 +18,10 @@ class Method:
 
     def __set_name__(self, owner, name):
         self.name = name
+
+        if self.method_class is not None:
+            return
+
         if owner.method_class:
             self.method_class = owner.method_class
         else:


### PR DESCRIPTION
Prior to this PR, customizing the behavior of the rest decorators by passing the `method_class` argument to them was impossible, because the code in the `Method` class used to overwrite the `method_class` field with a different value. With this fixed, the users will be able to inherit from the `BoundMethod` or its descendants and implement the methods as needed, then pass the classname to `get`, `post`, etc.