### PR TITLE
Feature: BodyPart Transformer

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -132,6 +132,46 @@ After dumping body is converted to plain text using ``request_body_post_dump`` w
             ...
 
 
+Building body from parts
+------------------------
+
+In some cases, you may want to build the request body from multiple arguments, for example, when you do not want to create a separate model for the request body.
+You can use ``BodyPart(name, template=None)`` to achieve this.
+
+* ``name`` - the name of the field in the request body.
+* ``template`` - an optional template to format the value. ``BodyPart`` uses the same template implementation as ``Header`` and ``Query``. It can be a format-string, a lambda, or a function.
+
+The behavior of ``request_body_dumper`` and ``request_body_post_dump`` is the same as when using ``Body``.
+
+.. code-block:: python
+
+    from descanso.request_transformers import BodyPart
+    from descanso import RestBuilder
+
+
+    rest = RestBuilder()
+
+
+    class Client:
+        @rest.post(
+            "/",
+            BodyPart("user_id"),
+            BodyPart("user_name", "{first_name}-{last_name}"),
+            BodyPart("level", lambda power: power + 1),
+        )
+        def create_user(
+            self,
+            user_id: int,
+            first_name: str,
+            last_name: str,
+            power: int,
+        ) -> None:
+            ...
+
+.. note::
+    You can not use ``Body`` and ``BodyPart`` at the same time in the same method.
+
+
 Response configuration
 ===========================
 

--- a/examples/body_parts.py
+++ b/examples/body_parts.py
@@ -1,0 +1,66 @@
+import logging
+from dataclasses import dataclass
+
+from adaptix import NameStyle, Retort, name_mapping
+from requests import Session
+
+from descanso import RestBuilder
+from descanso.http.requests import RequestsClient
+from descanso.request_transformers import BodyPart
+
+
+@dataclass
+class Todo:
+    id: int
+    user_id: int
+    title: str
+    completed: bool
+
+
+retort = Retort(
+    recipe=[
+        name_mapping(name_style=NameStyle.CAMEL),
+    ],
+)
+rest = RestBuilder(
+    request_body_dumper=retort,
+    response_body_loader=retort,
+    query_param_dumper=Retort(),
+)
+
+
+class RealClient(RequestsClient):
+    def __init__(self):
+        super().__init__(
+            base_url="https://jsonplaceholder.typicode.com/",
+            session=Session(),
+        )
+
+    @rest.post(
+        "todos",
+        BodyPart("id"),
+        BodyPart("user_id"),
+        BodyPart("title"),
+        BodyPart("completed"),
+    )
+    async def create_todo(
+        self,
+        id: int,
+        user_id: int,
+        title: str,
+        completed: bool,
+    ) -> Todo:
+        """POST method"""
+        raise NotImplementedError
+
+
+logging.basicConfig(level=logging.INFO)
+client = RealClient()
+print(
+    client.create_todo(
+        id=123456789,
+        user_id=111222333,
+        title="By Tishka17",
+        completed=False,
+    ),
+)

--- a/src/descanso/exceptions.py
+++ b/src/descanso/exceptions.py
@@ -22,3 +22,7 @@ class ClientError(HttpStatusError):
 
 class ServerError(HttpStatusError):
     pass
+
+
+class SpecificationError(ValueError):
+    pass

--- a/src/descanso/jsonrpc.py
+++ b/src/descanso/jsonrpc.py
@@ -16,6 +16,7 @@ from descanso.builder_base import (
     UrlSrc,
     url_transformer,
 )
+from descanso.exceptions import SpecificationError
 from descanso.method_descriptor import MethodBinder
 from descanso.method_spec import MethodSpec
 from descanso.request import (
@@ -297,10 +298,17 @@ class JsonRPCBuilder:
         self._add_default_jsonrpc_method(spec)
         self._add_body_transformer(spec)
 
-        if self._get_body_field(spec) or self._get_body_part_fields(spec):
+        body_field = self._get_body_field(spec)
+        body_part_fields = self._get_body_part_fields(spec)
+        if body_field and body_part_fields:
+            raise SpecificationError(
+                "Body and BodyPart can not be used at the same time",
+            )
+
+        if body_field or body_part_fields:
             dumper = self.params.get("request_body_dumper")
             if dumper:
-                if self._get_body_field(spec):
+                if body_field:
                     self._add_request_transformer(spec, BodyModelDump(dumper))
                 else:
                     self._add_request_transformer(spec, BodyPartDump(dumper))

--- a/src/descanso/jsonrpc.py
+++ b/src/descanso/jsonrpc.py
@@ -28,6 +28,7 @@ from descanso.request import (
 from descanso.request_transformers import (
     Body,
     BodyModelDump,
+    BodyPartDump,
     JsonDump,
     Method,
 )
@@ -271,6 +272,13 @@ class JsonRPCBuilder:
                 return field
         return None
 
+    def _get_body_part_fields(self, spec: MethodSpec) -> list[FieldOut]:
+        return [
+            field
+            for field in spec.fields_out
+            if field.dest is FieldDestination.BODY_PART
+        ]
+
     def _add_body_transformer(self, spec: MethodSpec):
         body_out = self._get_body_field(spec)
         if body_out is None:
@@ -289,10 +297,13 @@ class JsonRPCBuilder:
         self._add_default_jsonrpc_method(spec)
         self._add_body_transformer(spec)
 
-        if self._get_body_field(spec):
+        if self._get_body_field(spec) or self._get_body_part_fields(spec):
             dumper = self.params.get("request_body_dumper")
             if dumper:
-                self._add_request_transformer(spec, BodyModelDump(dumper))
+                if self._get_body_field(spec):
+                    self._add_request_transformer(spec, BodyModelDump(dumper))
+                else:
+                    self._add_request_transformer(spec, BodyPartDump(dumper))
 
         id_generator = self.params.get("id_generator", ...)
         if id_generator is ...:

--- a/src/descanso/jsonrpc.py
+++ b/src/descanso/jsonrpc.py
@@ -294,10 +294,7 @@ class JsonRPCBuilder:
             body_name = field.name
             self._add_request_transformer(spec, Body(field.name))
 
-    def _add_default_request_body_transformers(self, spec: MethodSpec):
-        self._add_default_jsonrpc_method(spec)
-        self._add_body_transformer(spec)
-
+    def _add_request_body_dumper(self, spec: MethodSpec):
         body_field = self._get_body_field(spec)
         body_part_fields = self._get_body_part_fields(spec)
         if body_field and body_part_fields:
@@ -312,6 +309,7 @@ class JsonRPCBuilder:
                 else:
                     self._add_request_transformer(spec, BodyPartDump(dumper))
 
+    def _add_jsonrpc_id_generator(self, spec: MethodSpec):
         id_generator = self.params.get("id_generator", ...)
         if id_generator is ...:
             self._add_request_transformer(spec, JsonRPCIdGenerator())
@@ -321,22 +319,35 @@ class JsonRPCBuilder:
                 JsonRPCIdGenerator(id_generator),
             )
 
-        url_src = self.params.get("url") or ""
-        self._add_request_transformer(spec, url_transformer(url_src))
-
-        self._add_request_transformer(spec, PackJsonRPC())
-
+    def _add_request_body_post_dump(self, spec: MethodSpec):
         post_dump = self.params.get("request_body_post_dump", ...)
         if post_dump is ...:
             self._add_request_transformer(spec, JsonDump())
         elif post_dump:
             self._add_request_transformer(spec, post_dump)
 
+    def _add_http_method(self, spec: MethodSpec):
         http_method = self.params.get("http_method", ...)
         if http_method is ...:
             self._add_request_transformer(spec, Method("POST"))
         elif http_method:
             self._add_request_transformer(spec, Method(http_method))
+
+    def _add_default_request_body_transformers(self, spec: MethodSpec):
+        self._add_default_jsonrpc_method(spec)
+        self._add_body_transformer(spec)
+
+        self._add_request_body_dumper(spec)
+
+        self._add_jsonrpc_id_generator(spec)
+
+        url_src = self.params.get("url") or ""
+        self._add_request_transformer(spec, url_transformer(url_src))
+
+        self._add_request_transformer(spec, PackJsonRPC())
+
+        self._add_request_body_post_dump(spec)
+        self._add_http_method(spec)
 
     def _add_default_response_transformers(self, spec: MethodSpec) -> None:
         error_raiser = self.params.get("error_raiser", ...)

--- a/src/descanso/jsonrpc.py
+++ b/src/descanso/jsonrpc.py
@@ -301,9 +301,8 @@ class JsonRPCBuilder:
         body_field = self._get_body_field(spec)
         body_part_fields = self._get_body_part_fields(spec)
         if body_field and body_part_fields:
-            raise SpecificationError(
-                "Body and BodyPart can not be used at the same time",
-            )
+            msg = "Body and BodyPart can not be used at the same time"
+            raise SpecificationError(msg)
 
         if body_field or body_part_fields:
             dumper = self.params.get("request_body_dumper")

--- a/src/descanso/request.py
+++ b/src/descanso/request.py
@@ -40,6 +40,7 @@ class FieldDestination(Enum):
     URL = "url"
     HEADER = "headers"
     BODY = "body"
+    BODY_PART = "body_part"
     FILE = "files"
     QUERY = "query_params"
     EXTRA = "extras"

--- a/src/descanso/request_transformers.py
+++ b/src/descanso/request_transformers.py
@@ -431,7 +431,10 @@ class BodyPartDump(BaseRequestTransformer):
             if f.dest == FieldDestination.BODY_PART
         }
         stub_dataclass = make_dataclass("StubDataclass", types.items())
-        request.body = self.dumper.dump(stub_dataclass(**request.body), stub_dataclass)
+        request.body = self.dumper.dump(
+            stub_dataclass(**request.body),
+            stub_dataclass,
+        )
         return request
 
     def __repr__(self):

--- a/src/descanso/request_transformers.py
+++ b/src/descanso/request_transformers.py
@@ -347,25 +347,13 @@ class Body(BaseRequestTransformer):
         return f"{self.__class__.__name__}({self.arg!r})"
 
 
-class BodyPart(BaseRequestTransformer):
-    def __init__(self, arg: str):
-        self.arg = arg
-
-    def transform_fields(
-        self,
-        fields_in: Sequence[FieldIn],
-    ) -> Sequence[FieldOut]:
-        for field in fields_in:
-            if field.name == self.arg:
-                field.consumed_by.append(self)
-                return [
-                    FieldOut(
-                        name=field.name,
-                        dest=FieldDestination.BODY_PART,
-                        type_hint=field.type_hint,
-                    ),
-                ]
-        return []
+class BodyPart(DestTransformer):
+    def __init__(self, name_out: str, template: DataTemplate = None):
+        super().__init__(
+            name_out=name_out,
+            template=template,
+            dest=FieldDestination.BODY_PART,
+        )
 
     def transform_request(
         self,
@@ -374,18 +362,15 @@ class BodyPart(BaseRequestTransformer):
         fields_out: Sequence[FieldOut],
         data: dict[str, Any],
     ) -> HttpRequest:
-        if self.arg not in data:
-            return request
+        value = self.template(
+            **{k: v for k, v in data.items() if k in self.args},
+        )
 
         if request.body is None:
-            request.body = {self.arg: data[self.arg]}
-        else:
-            request.body[self.arg] = data[self.arg]
+            request.body = {}
+        request.body[self.name_out] = value
 
         return request
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}({self.arg!r})"
 
 
 class BodyModelDump(BaseRequestTransformer):

--- a/src/descanso/request_transformers.py
+++ b/src/descanso/request_transformers.py
@@ -2,6 +2,7 @@ import itertools
 import json
 import string
 from collections.abc import Callable, Iterator, Sequence
+from dataclasses import make_dataclass
 from inspect import getfullargspec
 from typing import Any, get_type_hints
 
@@ -346,6 +347,47 @@ class Body(BaseRequestTransformer):
         return f"{self.__class__.__name__}({self.arg!r})"
 
 
+class BodyPart(BaseRequestTransformer):
+    def __init__(self, arg: str):
+        self.arg = arg
+
+    def transform_fields(
+        self,
+        fields_in: Sequence[FieldIn],
+    ) -> Sequence[FieldOut]:
+        for field in fields_in:
+            if field.name == self.arg:
+                field.consumed_by.append(self)
+                return [
+                    FieldOut(
+                        name=field.name,
+                        dest=FieldDestination.BODY_PART,
+                        type_hint=field.type_hint,
+                    ),
+                ]
+        return []
+
+    def transform_request(
+        self,
+        request: HttpRequest,
+        fields_in: Sequence[FieldIn],
+        fields_out: Sequence[FieldOut],
+        data: dict[str, Any],
+    ) -> HttpRequest:
+        if self.arg not in data:
+            return request
+
+        if request.body is None:
+            request.body = {self.arg: data[self.arg]}
+        else:
+            request.body[self.arg] = data[self.arg]
+
+        return request
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.arg!r})"
+
+
 class BodyModelDump(BaseRequestTransformer):
     def __init__(self, dumper: Dumper) -> None:
         self.dumper = dumper
@@ -366,6 +408,30 @@ class BodyModelDump(BaseRequestTransformer):
             Any,
         )
         request.body = self.dumper.dump(request.body, type_hint)
+        return request
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.dumper!r})"
+
+
+class BodyPartDump(BaseRequestTransformer):
+    def __init__(self, dumper: Dumper) -> None:
+        self.dumper = dumper
+
+    def transform_request(
+        self,
+        request: HttpRequest,
+        fields_in: Sequence[FieldIn],
+        fields_out: Sequence[FieldOut],
+        data: dict[str, Any],
+    ) -> HttpRequest:
+        types = {
+            f.name: f.type_hint
+            for f in fields_out
+            if f.dest == FieldDestination.BODY_PART
+        }
+        stub_dataclass = make_dataclass("StubDataclass", types.items())
+        request.body = self.dumper.dump(stub_dataclass(**request.body), stub_dataclass)
         return request
 
     def __repr__(self):

--- a/src/descanso/rest_builder.py
+++ b/src/descanso/rest_builder.py
@@ -16,6 +16,7 @@ from descanso.builder_base import (
     UrlSrc,
     url_transformer,
 )
+from descanso.exceptions import SpecificationError
 from descanso.method_descriptor import MethodBinder
 from descanso.method_spec import MethodSpec
 from descanso.request import FieldDestination, FieldOut, RequestTransformer
@@ -172,10 +173,17 @@ class RestBuilder(Decorator):
             if not body_out and field.name == default_body_name:
                 self._add_request_transformer(spec, Body(field.name))
 
-        if self._get_body_field(spec) or self._get_body_part_fields(spec):
+        body_field = self._get_body_field(spec)
+        body_part_fields = self._get_body_part_fields(spec)
+        if body_field and body_part_fields:
+            raise SpecificationError(
+                "Body and BodyPart can not be used at the same time",
+            )
+
+        if body_field or body_part_fields:
             dumper = self.params.get("request_body_dumper")
             if dumper:
-                if self._get_body_field(spec):
+                if body_field:
                     self._add_request_transformer(spec, BodyModelDump(dumper))
                 else:
                     self._add_request_transformer(spec, BodyPartDump(dumper))

--- a/src/descanso/rest_builder.py
+++ b/src/descanso/rest_builder.py
@@ -163,6 +163,21 @@ class RestBuilder(Decorator):
             if field.dest is FieldDestination.BODY_PART
         ]
 
+    def _add_request_body_dumper(self, spec: MethodSpec):
+        dumper = self.params.get("request_body_dumper")
+        if dumper:
+            if self._get_body_field(spec):
+                self._add_request_transformer(spec, BodyModelDump(dumper))
+            else:
+                self._add_request_transformer(spec, BodyPartDump(dumper))
+
+    def _add_request_body_post_dump(self, spec: MethodSpec):
+        post_dump = self.params.get("request_body_post_dump", ...)
+        if post_dump is ...:
+            self._add_request_transformer(spec, JsonDump())
+        elif post_dump:
+            self._add_request_transformer(spec, post_dump)
+
     def _add_default_request_body_transformers(self, spec: MethodSpec):
         default_body_name = self.params.get("body_name", DEFAULT_BODY_PARAM)
 
@@ -180,18 +195,8 @@ class RestBuilder(Decorator):
             raise SpecificationError(msg)
 
         if body_field or body_part_fields:
-            dumper = self.params.get("request_body_dumper")
-            if dumper:
-                if body_field:
-                    self._add_request_transformer(spec, BodyModelDump(dumper))
-                else:
-                    self._add_request_transformer(spec, BodyPartDump(dumper))
-
-            post_dump = self.params.get("request_body_post_dump", ...)
-            if post_dump is ...:
-                self._add_request_transformer(spec, JsonDump())
-            elif post_dump:
-                self._add_request_transformer(spec, post_dump)
+            self._add_request_body_dumper(spec)
+            self._add_request_body_post_dump(spec)
 
     def _add_default_query_transformers(self, spec: MethodSpec):
         for field in spec.fields_in:

--- a/src/descanso/rest_builder.py
+++ b/src/descanso/rest_builder.py
@@ -176,9 +176,8 @@ class RestBuilder(Decorator):
         body_field = self._get_body_field(spec)
         body_part_fields = self._get_body_part_fields(spec)
         if body_field and body_part_fields:
-            raise SpecificationError(
-                "Body and BodyPart can not be used at the same time",
-            )
+            msg = "Body and BodyPart can not be used at the same time"
+            raise SpecificationError(msg)
 
         if body_field or body_part_fields:
             dumper = self.params.get("request_body_dumper")

--- a/src/descanso/rest_builder.py
+++ b/src/descanso/rest_builder.py
@@ -22,6 +22,7 @@ from descanso.request import FieldDestination, FieldOut, RequestTransformer
 from descanso.request_transformers import (
     Body,
     BodyModelDump,
+    BodyPartDump,
     FormQuery,
     JsonDump,
     Method,
@@ -154,6 +155,13 @@ class RestBuilder(Decorator):
                 return field
         return None
 
+    def _get_body_part_fields(self, spec: MethodSpec) -> list[FieldOut]:
+        return [
+            field
+            for field in spec.fields_out
+            if field.dest is FieldDestination.BODY_PART
+        ]
+
     def _add_default_request_body_transformers(self, spec: MethodSpec):
         default_body_name = self.params.get("body_name", DEFAULT_BODY_PARAM)
 
@@ -164,10 +172,13 @@ class RestBuilder(Decorator):
             if not body_out and field.name == default_body_name:
                 self._add_request_transformer(spec, Body(field.name))
 
-        if self._get_body_field(spec):
+        if self._get_body_field(spec) or self._get_body_part_fields(spec):
             dumper = self.params.get("request_body_dumper")
             if dumper:
-                self._add_request_transformer(spec, BodyModelDump(dumper))
+                if self._get_body_field(spec):
+                    self._add_request_transformer(spec, BodyModelDump(dumper))
+                else:
+                    self._add_request_transformer(spec, BodyPartDump(dumper))
 
             post_dump = self.params.get("request_body_post_dump", ...)
             if post_dump is ...:

--- a/tests/builders/test_jsonrpc.py
+++ b/tests/builders/test_jsonrpc.py
@@ -1,6 +1,10 @@
+from typing import Any
+
+import pytest
 from dirty_equals import IsList
 
 from descanso import JsonRPCBuilder
+from descanso.exceptions import SpecificationError
 from descanso.jsonrpc import (
     JsonRPCErrorRaiser,
     JsonRPCIdGenerator,
@@ -11,6 +15,7 @@ from descanso.jsonrpc import (
 from descanso.request_transformers import (
     Body,
     BodyModelDump,
+    BodyPart,
     JsonDump,
     Method,
     Skip,
@@ -176,3 +181,12 @@ def test_default_jsonrpc_method_with_transformers_and_params() -> None:
         check_order=False,
         length=...,
     )
+
+
+def test_body_and_body_part_together() -> None:
+    jsonrpc = JsonRPCBuilder()
+
+    with pytest.raises(SpecificationError):
+
+        @jsonrpc("/", Body("body"), BodyPart("a"))
+        def method(self, body: Any, a: int): ...

--- a/tests/builders/test_rest.py
+++ b/tests/builders/test_rest.py
@@ -1,12 +1,15 @@
 from typing import Any
 
+import pytest
 from dirty_equals import Contains
 
 from descanso import Loader, RestBuilder
 from descanso.client import Dumper
+from descanso.exceptions import SpecificationError
 from descanso.request_transformers import (
     Body,
     BodyModelDump,
+    BodyPart,
     FormQuery,
     JsonDump,
     Method,
@@ -171,3 +174,12 @@ def test_override_params():
         error_raiser,
         response_body_pre_load2,
     ]
+
+
+def test_body_and_body_part_together() -> None:
+    rest = RestBuilder()
+
+    with pytest.raises(SpecificationError):
+
+        @rest.post("/", Body("body"), BodyPart("a"))
+        def method(self, body: Any, a: int): ...

--- a/tests/request_transformers/test_body_part.py
+++ b/tests/request_transformers/test_body_part.py
@@ -1,4 +1,3 @@
-
 from typing import Any
 
 import pytest
@@ -58,7 +57,7 @@ def test_body_part(fields_in):
             name="x",
             dest=FieldDestination.BODY_PART,
             type_hint=int,
-        )
+        ),
     ]
     assert consumed_fields([fields_in[0]], transformer) == ["x"]
 
@@ -104,8 +103,16 @@ def test_body_part_dump_with_adaptix(fields_in):
     transformer = BodyPartDump(retort)
 
     fields_out_adaptix = [
-        FieldOut(name="user_id", dest=FieldDestination.BODY_PART, type_hint=int),
-        FieldOut(name="user_name", dest=FieldDestination.BODY_PART, type_hint=str),
+        FieldOut(
+            name="user_id",
+            dest=FieldDestination.BODY_PART,
+            type_hint=int,
+        ),
+        FieldOut(
+            name="user_name",
+            dest=FieldDestination.BODY_PART,
+            type_hint=str,
+        ),
     ]
 
     request = HttpRequest(body={"user_id": 1, "user_name": "test"})

--- a/tests/request_transformers/test_body_part.py
+++ b/tests/request_transformers/test_body_part.py
@@ -1,0 +1,118 @@
+
+from typing import Any
+
+import pytest
+from adaptix import NameStyle, Retort, name_mapping
+
+from descanso import Dumper
+from descanso.request import (
+    FieldDestination,
+    FieldIn,
+    FieldOut,
+    HttpRequest,
+)
+from descanso.request_transformers import BodyPart, BodyPartDump
+from tests.request_transformers.utills import consumed_fields
+
+
+class BodyPartModel:
+    pass
+
+
+class StubDumper(Dumper):
+    def dump(self, data: Any, class_: Any) -> Any:
+        return ["stub", data, class_]
+
+
+@pytest.fixture
+def fields_in():
+    return [
+        FieldIn("x", int),
+        FieldIn("y", str),
+        FieldIn("user_id", int),
+        FieldIn("user_name", str),
+    ]
+
+
+@pytest.fixture
+def fields_out():
+    return [
+        FieldOut(
+            name="x",
+            dest=FieldDestination.BODY_PART,
+            type_hint=int,
+        ),
+        FieldOut(
+            name="y",
+            dest=FieldDestination.BODY_PART,
+            type_hint=str,
+        ),
+    ]
+
+
+def test_body_part(fields_in):
+    transformer = BodyPart(arg="x")
+    assert str(transformer)
+    assert transformer.transform_fields([fields_in[0]]) == [
+        FieldOut(
+            name="x",
+            dest=FieldDestination.BODY_PART,
+            type_hint=int,
+        )
+    ]
+    assert consumed_fields([fields_in[0]], transformer) == ["x"]
+
+    request = HttpRequest()
+    data = {"x": 123}
+
+    result_request = transformer.transform_request(request, [], [], data)
+    assert result_request.body == {"x": 123}
+
+    request.body = {"username": "test"}
+    result_request = transformer.transform_request(request, [], [], data)
+    assert result_request.body == {"username": "test", "x": 123}
+
+
+def test_body_part_dump(fields_in, fields_out):
+    transformer = BodyPartDump(StubDumper())
+    assert str(transformer)
+    assert transformer.transform_fields(fields_in) == []
+    assert consumed_fields(fields_in, transformer) == []
+
+    request = HttpRequest(body={"x": 1, "y": "test"})
+    result = transformer.transform_request(
+        request,
+        fields_in,
+        fields_out,
+        {"x": 1, "y": "test"},
+    )
+    assert isinstance(result.body, list)
+    assert result.body[0] == "stub"
+
+    dumped_obj = result.body[1]
+    assert dumped_obj.x == 1
+    assert dumped_obj.y == "test"
+
+    dumped_class = result.body[2]
+    assert dumped_class.__name__ == "StubDataclass"
+    assert dumped_class.__annotations__["x"] is int
+    assert dumped_class.__annotations__["y"] is str
+
+
+def test_body_part_dump_with_adaptix(fields_in):
+    retort = Retort(recipe=[name_mapping(name_style=NameStyle.CAMEL)])
+    transformer = BodyPartDump(retort)
+
+    fields_out_adaptix = [
+        FieldOut(name="user_id", dest=FieldDestination.BODY_PART, type_hint=int),
+        FieldOut(name="user_name", dest=FieldDestination.BODY_PART, type_hint=str),
+    ]
+
+    request = HttpRequest(body={"user_id": 1, "user_name": "test"})
+    result = transformer.transform_request(
+        request,
+        fields_in,
+        fields_out_adaptix,
+        {"user_id": 1, "user_name": "test"},
+    )
+    assert result.body == {"userId": 1, "userName": "test"}

--- a/tests/request_transformers/test_body_part.py
+++ b/tests/request_transformers/test_body_part.py
@@ -3,14 +3,15 @@ from typing import Any
 import pytest
 from adaptix import NameStyle, Retort, name_mapping
 
-from descanso import Dumper
+from descanso import Dumper, RestBuilder
+from descanso.exceptions import SpecificationError
 from descanso.request import (
     FieldDestination,
     FieldIn,
     FieldOut,
     HttpRequest,
 )
-from descanso.request_transformers import BodyPart, BodyPartDump
+from descanso.request_transformers import Body, BodyPart, BodyPartDump
 from tests.request_transformers.utills import consumed_fields
 
 
@@ -50,7 +51,7 @@ def fields_out():
 
 
 def test_body_part(fields_in):
-    transformer = BodyPart(arg="x")
+    transformer = BodyPart("x")
     assert str(transformer)
     assert transformer.transform_fields([fields_in[0]]) == [
         FieldOut(
@@ -70,6 +71,25 @@ def test_body_part(fields_in):
     request.body = {"username": "test"}
     result_request = transformer.transform_request(request, [], [], data)
     assert result_request.body == {"username": "test", "x": 123}
+
+
+def test_body_part_template(fields_in):
+    transformer = BodyPart("x", "hello-{y}")
+    assert str(transformer)
+    assert transformer.transform_fields(fields_in) == [
+        FieldOut(name="x", dest=FieldDestination.BODY_PART, type_hint=str),
+    ]
+    assert consumed_fields(fields_in, transformer) == ["y"]
+
+    request = HttpRequest()
+    data = {"y": "world"}
+    result_request = transformer.transform_request(
+        request,
+        fields_in,
+        [],
+        data,
+    )
+    assert result_request.body == {"x": "hello-world"}
 
 
 def test_body_part_dump(fields_in, fields_out):

--- a/tests/request_transformers/test_body_part.py
+++ b/tests/request_transformers/test_body_part.py
@@ -3,15 +3,14 @@ from typing import Any
 import pytest
 from adaptix import NameStyle, Retort, name_mapping
 
-from descanso import Dumper, RestBuilder
-from descanso.exceptions import SpecificationError
+from descanso import Dumper
 from descanso.request import (
     FieldDestination,
     FieldIn,
     FieldOut,
     HttpRequest,
 )
-from descanso.request_transformers import Body, BodyPart, BodyPartDump
+from descanso.request_transformers import BodyPart, BodyPartDump
 from tests.request_transformers.utills import consumed_fields
 
 
@@ -73,13 +72,34 @@ def test_body_part(fields_in):
     assert result_request.body == {"username": "test", "x": 123}
 
 
-def test_body_part_template(fields_in):
-    transformer = BodyPart("x", "hello-{y}")
+def make_body(y: str) -> str:
+    return f"hello-{y}"
+
+
+@pytest.mark.parametrize(
+    ("template", "expected_type_hint", "expected_consumed_fields"),
+    [
+        ("hello-{y}", str, ["y"]),
+        (lambda y: f"hello-{y}", Any, ["y"]),
+        (make_body, str, ["y"]),
+    ],
+)
+def test_body_part_templates(
+    fields_in,
+    template,
+    expected_type_hint,
+    expected_consumed_fields,
+):
+    transformer = BodyPart("x", template)
     assert str(transformer)
     assert transformer.transform_fields(fields_in) == [
-        FieldOut(name="x", dest=FieldDestination.BODY_PART, type_hint=str),
+        FieldOut(
+            name="x",
+            dest=FieldDestination.BODY_PART,
+            type_hint=expected_type_hint,
+        ),
     ]
-    assert consumed_fields(fields_in, transformer) == ["y"]
+    assert consumed_fields(fields_in, transformer) == expected_consumed_fields
 
     request = HttpRequest()
     data = {"y": "world"}


### PR DESCRIPTION
# Feature: Assemble Request Body from Arguments

This PR adds the ability to construct a request body from multiple, individual function arguments.

## Problem Solved

The main goal is to avoid needing a separate `dataclass` for simple request bodies.

Before, creating a request body required passing a single model object. This is inconvenient for APIs that expect a flat JSON object, as it forces the creation of a new class just for the body schema. This PR allows defining body fields directly as function arguments.

## Implementation Details

The implementation uses two new request transformers: `BodyPart` and `BodyPartDump`.

### `BodyPart` Transformer

- The `BodyPart("arg_name")` transformer maps a function argument to a field in the request body.
- It can be applied to multiple arguments in the same function.
- During request processing, each `BodyPart` adds its key-value pair to the `request.body` dictionary.

### `BodyPartDump` Transformer

- The `RestBuilder` and `JsonRPCBuilder` automatically add the `BodyPartDump` transformer when `BodyPart` arguments are detected.
- It serializes the dictionary of body parts using a type-aware `dumper` (like `adaptix.Retort`).
- To provide type context to the dumper, it dynamically creates a temporary `dataclass` from the collected `BodyPart` arguments and their types.
- This enables the dumper to perform operations like name style conversion (e.g., `snake_case` to `camelCase`).

### Example

```python
rest = RestBuilder(
    request_body_dumper=Retort(
        recipe=[name_mapping(name_style=NameStyle.CAMEL)]
    ),
)

@rest.post(
    "todos",
    BodyPart("id"),
    BodyPart("user_id"),
    BodyPart("title"),
)
def create_todo(self, id: int, user_id: int, title: str) -> Todo:
    pass

# Calling client.create_todo(id=1, user_id=99, title="Test")
# sends the following JSON body:
# {
#   "id": 1,
#   "userId": 99,
#   "title": "Test"
# }
```
