### PR TITLE
Add `QueryMask`

### DIFF
--- a/src/descanso/api/rest.py
+++ b/src/descanso/api/rest.py
@@ -21,7 +21,6 @@ from descanso.transformers.request import (
     JsonDump,
     Method,
     Query,
-    QueryMask,
     QueryModelDump,
 )
 from descanso.transformers.response import (
@@ -51,7 +50,6 @@ class BuilderParams(TypedDict, total=False):
     request_body_dumper: Dumper | None
     request_body_post_dump: RequestTransformer | None
     query_param_post_dump: RequestTransformer | None
-    default_query: QueryMask | None
 
     response_body_loader: Loader | None
     response_body_pre_load: ResponseTransformer | None
@@ -181,8 +179,6 @@ class RestBuilder(Decorator):
                 self._add_request_transformer(pipeline, post_dump)
 
     def _add_default_query_transformers(self, pipeline: MethodPipeline):
-        if query_mask := self.params.get("default_query"):
-            self._add_request_transformer(pipeline, query_mask)
         for field in pipeline.fields_in:
             if field.consumed_by:
                 continue

--- a/src/descanso/api/rest.py
+++ b/src/descanso/api/rest.py
@@ -20,7 +20,7 @@ from descanso.transformers.request import (
     FormQuery,
     JsonDump,
     Method,
-    Query,
+    QueryMask,
     QueryModelDump,
 )
 from descanso.transformers.response import (
@@ -179,10 +179,7 @@ class RestBuilder(Decorator):
                 self._add_request_transformer(pipeline, post_dump)
 
     def _add_default_query_transformers(self, pipeline: MethodPipeline):
-        for field in pipeline.fields_in:
-            if field.consumed_by:
-                continue
-            self._add_request_transformer(pipeline, Query(field.name))
+        self._add_request_transformer(pipeline, QueryMask())
 
         if dumper := self.params.get("query_param_dumper"):
             self._add_request_transformer(pipeline, QueryModelDump(dumper))

--- a/src/descanso/api/rest.py
+++ b/src/descanso/api/rest.py
@@ -183,11 +183,10 @@ class RestBuilder(Decorator):
     def _add_default_query_transformers(self, pipeline: MethodPipeline):
         if query_mask := self.params.get("default_query"):
             self._add_request_transformer(pipeline, query_mask)
-        else:
-            for field in pipeline.fields_in:
-                if field.consumed_by:
-                    continue
-                self._add_request_transformer(pipeline, Query(field.name))
+        for field in pipeline.fields_in:
+            if field.consumed_by:
+                continue
+            self._add_request_transformer(pipeline, Query(field.name))
 
         if dumper := self.params.get("query_param_dumper"):
             self._add_request_transformer(pipeline, QueryModelDump(dumper))

--- a/src/descanso/api/rest.py
+++ b/src/descanso/api/rest.py
@@ -21,6 +21,7 @@ from descanso.transformers.request import (
     JsonDump,
     Method,
     Query,
+    QueryMask,
     QueryModelDump,
 )
 from descanso.transformers.response import (
@@ -50,6 +51,7 @@ class BuilderParams(TypedDict, total=False):
     request_body_dumper: Dumper | None
     request_body_post_dump: RequestTransformer | None
     query_param_post_dump: RequestTransformer | None
+    default_query: QueryMask | None
 
     response_body_loader: Loader | None
     response_body_pre_load: ResponseTransformer | None
@@ -179,10 +181,13 @@ class RestBuilder(Decorator):
                 self._add_request_transformer(pipeline, post_dump)
 
     def _add_default_query_transformers(self, pipeline: MethodPipeline):
-        for field in pipeline.fields_in:
-            if field.consumed_by:
-                continue
-            self._add_request_transformer(pipeline, Query(field.name))
+        if query_mask := self.params.get("default_query"):
+            self._add_request_transformer(pipeline, query_mask)
+        else:
+            for field in pipeline.fields_in:
+                if field.consumed_by:
+                    continue
+                self._add_request_transformer(pipeline, Query(field.name))
 
         if dumper := self.params.get("query_param_dumper"):
             self._add_request_transformer(pipeline, QueryModelDump(dumper))
@@ -211,11 +216,13 @@ class RestBuilder(Decorator):
 
         loader = self.params.get("response_body_loader")
         if pipeline.result_type is HttpResponse:
-            pipeline.response_transformers.append(KeepResponse(need_body=False))
+            pipeline.response_transformers.append(
+                KeepResponse(need_body=False),
+            )
         elif (
-                loader
-                and pipeline.result_type is not Any
-                and pipeline.result_type is not object
+            loader
+            and pipeline.result_type is not Any
+            and pipeline.result_type is not object
         ):
             pipeline.response_transformers.append(
                 BodyModelLoad(pipeline.result_type, loader=loader),

--- a/src/descanso/transformers/request.py
+++ b/src/descanso/transformers/request.py
@@ -253,12 +253,13 @@ class Query(DestTransformer):
 class QueryMask(BaseRequestTransformer):
     def __init__(
         self,
-        name_style: Callable[[str], str],
+        name_style: Callable[[str], str] | None = None,
         regex: str | None = None,
     ) -> None:
         self.regex = regex
         self.pattern = re.compile(regex) if regex else None
         self.name_style = name_style
+        self._transform_name = self.name_style or (lambda n: n)
 
     def transform_fields(
         self,
@@ -275,7 +276,7 @@ class QueryMask(BaseRequestTransformer):
             field.consumed_by.append(self)
             fields_out.append(
                 FieldOut(
-                    name=self.name_style(field.name),
+                    name=self._transform_name(field.name),
                     dest=FieldDestination.QUERY,
                     type_hint=field.type_hint,
                 ),
@@ -296,13 +297,15 @@ class QueryMask(BaseRequestTransformer):
             if field.name not in data:
                 continue
 
-            new_name = self.name_style(field.name)
+            new_name = self._transform_name(field.name)
             value = data[field.name]
             request.query_params.append((new_name, value))
         return request
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(re={self.regex!r}, name_style={self.name_style!r})"
+        return (
+            f"{self.__class__.__name__}({self.regex!r}, {self.name_style!r})"
+        )
 
 
 class Url(BaseRequestTransformer):

--- a/src/descanso/transformers/request.py
+++ b/src/descanso/transformers/request.py
@@ -253,12 +253,12 @@ class Query(DestTransformer):
 class QueryMask(BaseRequestTransformer):
     def __init__(
         self,
+        name_style: Callable[[str], str],
         regex: str | None = None,
-        name_style: Callable[[str], str] | None = None,
     ) -> None:
         self.regex = regex
         self.pattern = re.compile(regex) if regex else None
-        self.name_style = name_style or (lambda name: name)
+        self.name_style = name_style
 
     def transform_fields(
         self,

--- a/src/descanso/transformers/request.py
+++ b/src/descanso/transformers/request.py
@@ -1,5 +1,6 @@
 import itertools
 import json
+import re
 import string
 from collections.abc import Callable, Iterator, Sequence
 from inspect import getfullargspec
@@ -247,6 +248,61 @@ class Query(DestTransformer):
             dest=FieldDestination.QUERY,
             type_hint=type_hint,
         )
+
+
+class QueryMask(BaseRequestTransformer):
+    def __init__(
+        self,
+        regex: str | None = None,
+        name_style: Callable[[str], str] | None = None,
+    ) -> None:
+        self.regex = regex
+        self.pattern = re.compile(regex) if regex else None
+        self.name_style = name_style or (lambda name: name)
+
+    def transform_fields(
+        self,
+        spec: MethodSpec,
+        fields_in: Sequence[FieldIn],
+    ) -> Sequence[FieldOut]:
+        fields_out = []
+        for field in fields_in:
+            if field.consumed_by:
+                continue
+            if self.pattern and not self.pattern.fullmatch(field.name):
+                continue
+
+            field.consumed_by.append(self)
+            fields_out.append(
+                FieldOut(
+                    name=self.name_style(field.name),
+                    dest=FieldDestination.QUERY,
+                    type_hint=field.type_hint,
+                ),
+            )
+        return fields_out
+
+    def transform_request(
+        self,
+        spec: MethodSpec,
+        request: HttpRequest,
+        fields_in: Sequence[FieldIn],
+        fields_out: Sequence[FieldOut],
+        data: dict[str, Any],
+    ) -> HttpRequest:
+        for field in fields_in:
+            if self not in field.consumed_by:
+                continue
+            if field.name not in data:
+                continue
+
+            new_name = self.name_style(field.name)
+            value = data[field.name]
+            request.query_params.append((new_name, value))
+        return request
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(re={self.regex!r}, name_style={self.name_style!r})"
 
 
 class Url(BaseRequestTransformer):

--- a/tests/api/test_rest.py
+++ b/tests/api/test_rest.py
@@ -38,7 +38,7 @@ def test_get_with_query():
     assert Api.do_get.spec.request_transformers == [
         dirty[Url](original_template="/foo"),
         dirty[Method](method="GET"),
-        dirty[Query](name_out="x", original_template=None),
+        dirty[QueryMask](),
         dirty[FormQuery](),
     ]
     assert Api.do_get.spec.response_transformers == [
@@ -60,6 +60,7 @@ def test_post_with_url_body():
         dirty[Method](method="POST"),
         dirty[Body](arg="body"),
         dirty[JsonDump](),
+        dirty[QueryMask](),
         dirty[FormQuery](),
     ]
     assert Api.do_post.spec.response_transformers == [
@@ -144,7 +145,7 @@ def test_params():
         dirty[Body](arg="x"),
         dirty[BodyModelDump](dumper=request_body_dumper),
         request_body_post_dump,
-        dirty[Query](name_out="body", original_template=None),
+        dirty[QueryMask](),
         dirty[QueryModelDump](dumper=query_param_dumper),
         query_param_post_dump,
     ]
@@ -179,24 +180,26 @@ def test_query_mask():
     def to_upper(s: str) -> str:
         return s.upper()
 
-    query_mask = QueryMask(to_upper, "^u.*$")
-    rest = RestBuilder(default_query=query_mask)
+    query_mask_a = QueryMask(to_upper, "^a.*$")
+    rest = RestBuilder(query_mask_a)
 
     class Api:
-        @rest.get("/")
-        def do_get(self, user_id: int, phone_number: str) -> Model: ...
+        @rest.get("/", Query("abc"))
+        def do_get(self, abc: int, abcqwerty: int, xyz: int) -> Model: ...
 
     assert Api.do_get.spec.request_transformers == [
         dirty[Url](original_template="/"),
         dirty[Method](method="GET"),
-        dirty[QueryMask](regex="^u.*$", name_style=to_upper),
-        dirty[Query](name_out="phone_number", original_template=None),
+        dirty[Query](name_out="abc", original_template=None),
+        query_mask_a,
+        dirty[QueryMask](),
         dirty[FormQuery](),
     ]
     assert Api.do_get.spec.fields_out == [
         FieldOut(None, FieldDestination.URL, str),
-        FieldOut("USER_ID", FieldDestination.QUERY, int),
-        FieldOut("phone_number", FieldDestination.QUERY, str),
+        FieldOut("abc", FieldDestination.QUERY, int),
+        FieldOut("ABCQWERTY", FieldDestination.QUERY, int),
+        FieldOut("xyz", FieldDestination.QUERY, int),
     ]
 
 
@@ -204,49 +207,24 @@ def test_multiply_query_masks():
     def to_upper(s: str) -> str:
         return s.upper()
 
-    query_mask = QueryMask(to_upper, "^u.*$")
-    rest = RestBuilder(default_query=query_mask)
+    query_mask_a = QueryMask(to_upper, "^a.*$")
+    query_mask_x = QueryMask(to_upper, "^x.*$")
+    rest = RestBuilder(query_mask_a)
 
     class Api:
-        @rest.get("/", QueryMask(to_upper, "^p.*$"))
-        def do_get(self, user_id: int, phone_number: str) -> Model: ...
+        @rest.get("/", query_mask_x)
+        def do_get(self, abc: int, xyz: str) -> Model: ...
 
     assert Api.do_get.spec.request_transformers == [
         dirty[Url](original_template="/"),
         dirty[Method](method="GET"),
-        dirty[QueryMask](regex="^p.*$", name_style=to_upper),
-        dirty[QueryMask](regex="^u.*$", name_style=to_upper),
+        query_mask_x,
+        query_mask_a,
+        dirty[QueryMask](),
         dirty[FormQuery](),
     ]
     assert Api.do_get.spec.fields_out == [
         FieldOut(None, FieldDestination.URL, str),
-        FieldOut("PHONE_NUMBER", FieldDestination.QUERY, str),
-        FieldOut("USER_ID", FieldDestination.QUERY, int),
-    ]
-
-
-def test_query_mask_override():
-    def to_upper(s: str) -> str:
-        return s.upper()
-
-    def to_title(s: str) -> str:
-        return s.title()
-
-    query_mask = QueryMask(to_upper, "^a.*$")
-    rest = RestBuilder(default_query=query_mask)
-
-    class Api:
-        @rest.get("/", QueryMask(to_title, "^a.*$"))
-        def do_get(self, abc: str) -> Model: ...
-
-    assert Api.do_get.spec.request_transformers == [
-        dirty[Url](original_template="/"),
-        dirty[Method](method="GET"),
-        dirty[QueryMask](regex="^a.*$", name_style=to_title),
-        dirty[QueryMask](regex="^a.*$", name_style=to_upper),
-        dirty[FormQuery](),
-    ]
-    assert Api.do_get.spec.fields_out == [
-        FieldOut(None, FieldDestination.URL, str),
-        FieldOut("Abc", FieldDestination.QUERY, str),
+        FieldOut("XYZ", FieldDestination.QUERY, str),
+        FieldOut("ABC", FieldDestination.QUERY, int),
     ]

--- a/tests/api/test_rest.py
+++ b/tests/api/test_rest.py
@@ -4,6 +4,7 @@ from dirty_equals import Contains
 
 from descanso import Loader, RestBuilder
 from descanso.client import Dumper
+from descanso.fields import FieldDestination, FieldOut
 from descanso.transformers.request import (
     Body,
     BodyModelDump,
@@ -11,6 +12,7 @@ from descanso.transformers.request import (
     JsonDump,
     Method,
     Query,
+    QueryMask,
     QueryModelDump,
     Skip,
     Url,
@@ -170,4 +172,81 @@ def test_override_params():
     assert Api.do_get.spec.response_transformers == [
         error_raiser,
         response_body_pre_load2,
+    ]
+
+
+def test_query_mask():
+    def to_upper(s: str) -> str:
+        return s.upper()
+
+    query_mask = QueryMask(to_upper, "^u.*$")
+    rest = RestBuilder(default_query=query_mask)
+
+    class Api:
+        @rest.get("/")
+        def do_get(self, user_id: int, phone_number: str) -> Model: ...
+
+    assert Api.do_get.spec.request_transformers == [
+        dirty[Url](original_template="/"),
+        dirty[Method](method="GET"),
+        dirty[QueryMask](regex="^u.*$", name_style=to_upper),
+        dirty[Query](name_out="phone_number", original_template=None),
+        dirty[FormQuery](),
+    ]
+    assert Api.do_get.spec.fields_out == [
+        FieldOut(None, FieldDestination.URL, str),
+        FieldOut("USER_ID", FieldDestination.QUERY, int),
+        FieldOut("phone_number", FieldDestination.QUERY, str),
+    ]
+
+
+def test_multiply_query_masks():
+    def to_upper(s: str) -> str:
+        return s.upper()
+
+    query_mask = QueryMask(to_upper, "^u.*$")
+    rest = RestBuilder(default_query=query_mask)
+
+    class Api:
+        @rest.get("/", QueryMask(to_upper, "^p.*$"))
+        def do_get(self, user_id: int, phone_number: str) -> Model: ...
+
+    assert Api.do_get.spec.request_transformers == [
+        dirty[Url](original_template="/"),
+        dirty[Method](method="GET"),
+        dirty[QueryMask](regex="^p.*$", name_style=to_upper),
+        dirty[QueryMask](regex="^u.*$", name_style=to_upper),
+        dirty[FormQuery](),
+    ]
+    assert Api.do_get.spec.fields_out == [
+        FieldOut(None, FieldDestination.URL, str),
+        FieldOut("PHONE_NUMBER", FieldDestination.QUERY, str),
+        FieldOut("USER_ID", FieldDestination.QUERY, int),
+    ]
+
+
+def test_query_mask_override():
+    def to_upper(s: str) -> str:
+        return s.upper()
+
+    def to_title(s: str) -> str:
+        return s.title()
+
+    query_mask = QueryMask(to_upper, "^a.*$")
+    rest = RestBuilder(default_query=query_mask)
+
+    class Api:
+        @rest.get("/", QueryMask(to_title, "^a.*$"))
+        def do_get(self, abc: str) -> Model: ...
+
+    assert Api.do_get.spec.request_transformers == [
+        dirty[Url](original_template="/"),
+        dirty[Method](method="GET"),
+        dirty[QueryMask](regex="^a.*$", name_style=to_title),
+        dirty[QueryMask](regex="^a.*$", name_style=to_upper),
+        dirty[FormQuery](),
+    ]
+    assert Api.do_get.spec.fields_out == [
+        FieldOut(None, FieldDestination.URL, str),
+        FieldOut("Abc", FieldDestination.QUERY, str),
     ]

--- a/tests/transformers/request/test_fields.py
+++ b/tests/transformers/request/test_fields.py
@@ -261,7 +261,13 @@ def snake_to_camel(u: str) -> str:
     ],
 )
 def test_query_mask(
-    spec, transformer, consumed, params, out, fields_in, data_in
+    spec,
+    transformer,
+    consumed,
+    params,
+    out,
+    fields_in,
+    data_in,
 ):
     fields_out = transformer.transform_fields(spec, fields_in)
     assert str(transformer)

--- a/tests/transformers/request/test_fields.py
+++ b/tests/transformers/request/test_fields.py
@@ -20,6 +20,7 @@ from descanso.transformers.request import (
     Header,
     Method,
     Query,
+    QueryMask,
     Skip,
     Url,
 )
@@ -32,12 +33,24 @@ def query_int(i: int) -> int:
 
 @pytest.fixture
 def fields_in():
-    return [FieldIn("i", int), FieldIn("s", str), FieldIn("a", Any)]
+    return [
+        FieldIn("i", int),
+        FieldIn("s", str),
+        FieldIn("a", Any),
+        FieldIn("user_id", int),
+        FieldIn("first_name", str),
+    ]
 
 
 @pytest.fixture
 def data_in():
-    return {"i": 1, "s": "hello", "a": "any"}
+    return {
+        "i": 1,
+        "s": "hello",
+        "a": "any",
+        "user_id": 123,
+        "first_name": "John",
+    }
 
 
 @pytest.mark.parametrize(
@@ -196,6 +209,60 @@ def test_header(spec, transformer, consumed, headers, out, fields_in, data_in):
     ],
 )
 def test_query(spec, transformer, consumed, params, out, fields_in, data_in):
+    fields_out = transformer.transform_fields(spec, fields_in)
+    assert str(transformer)
+    assert consumed_fields(fields_in, transformer) == consumed
+    assert fields_out == out
+    req = transformer.transform_request(
+        spec,
+        HttpRequest(),
+        fields_in,
+        fields_out,
+        data_in,
+    )
+    assert req == HttpRequest(query_params=params)
+
+
+def snake_to_camel(u: str) -> str:
+    s = u.split("_")
+    return s[0] + "".join(x.title() for x in s[1:])
+
+
+@pytest.mark.parametrize(
+    ("transformer", "consumed", "params", "out"),
+    [
+        (
+            QueryMask("user_id|first_name", name_style=snake_to_camel),
+            ["user_id", "first_name"],
+            [("userId", 123), ("firstName", "John")],
+            [
+                FieldOut("userId", FieldDestination.QUERY, int),
+                FieldOut("firstName", FieldDestination.QUERY, str),
+            ],
+        ),
+        (
+            QueryMask(name_style=lambda n: n.upper()),
+            ["i", "s", "a", "user_id", "first_name"],
+            [
+                ("I", 1),
+                ("S", "hello"),
+                ("A", "any"),
+                ("USER_ID", 123),
+                ("FIRST_NAME", "John"),
+            ],
+            [
+                FieldOut("I", FieldDestination.QUERY, int),
+                FieldOut("S", FieldDestination.QUERY, str),
+                FieldOut("A", FieldDestination.QUERY, Any),
+                FieldOut("USER_ID", FieldDestination.QUERY, int),
+                FieldOut("FIRST_NAME", FieldDestination.QUERY, str),
+            ],
+        ),
+    ],
+)
+def test_query_mask(
+    spec, transformer, consumed, params, out, fields_in, data_in
+):
     fields_out = transformer.transform_fields(spec, fields_in)
     assert str(transformer)
     assert consumed_fields(fields_in, transformer) == consumed

--- a/tests/transformers/request/test_fields.py
+++ b/tests/transformers/request/test_fields.py
@@ -232,7 +232,7 @@ def snake_to_camel(u: str) -> str:
     ("transformer", "consumed", "params", "out"),
     [
         (
-            QueryMask("user_id|first_name", name_style=snake_to_camel),
+            QueryMask(snake_to_camel, "user_id|first_name"),
             ["user_id", "first_name"],
             [("userId", 123), ("firstName", "John")],
             [
@@ -241,7 +241,7 @@ def snake_to_camel(u: str) -> str:
             ],
         ),
         (
-            QueryMask(name_style=lambda n: n.upper()),
+            QueryMask(lambda n: n.upper()),
             ["i", "s", "a", "user_id", "first_name"],
             [
                 ("I", 1),


### PR DESCRIPTION
This class allows to create masks to convert the names of certain query parameters through a regular expression.

Usage:
```python
class Api:
    @rest.get("/", QueryMask(lambda n: n.upper(), "^p.*$"))
    # only `phone_number` converts to `PHONE_NUMBER`
    def do_get(self, user_id: int, phone_number: str) -> Model: ...
```
If we need to set a default `QueryMask` for all rest methods, we can do it by setting `QueryMask` in `RestBuilder`:
```python
# we may not to use regex
query_mask = QueryMask(lambda n: n.upper())
rest = RestBuilder(query_mask)

class Api:
    # parameters `a`, `b`, `c` will be converted to the ​​`A`, `B`, and `C` respectively, 
    # but `d` will be ignored, because it is an explicit query parameter
    @rest.get("/", Query("d"))
    def do_get(self, a: int, b: int, c: int, d: int) -> Model: ...
```